### PR TITLE
creative: Place node at player position when pointing into the sky.

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -1,18 +1,10 @@
-if minetest.setting_getbool("creative_mode") and minetest.setting_getbool("place_at_location") then
-   -- Don't do anything with on_place(Should fix this so you don't
-   -- have to point at something to place a block)
-   function minetest.nodedef_default.on_place(itemstack, user, pointed)
-      local upos = user:getpos()
-      local node_name = itemstack:get_name()
-      minetest.set_node(upos, {name = node_name})
-   end
-   
-   -- Place at player's location instead(Doesn't work yet)
-   function minetest.nodedef_default.on_use(pos, node, user, itemstack, pointed_thing)
-      --      print(dump(user))
-      local upos = user:getpos()
-      local node_name = itemstack:get_name()
-      --      print(dump(upos)..node_name)
-      --      minetest.set_node(upos, {name = node_name})
-   end
+if minetest.setting_getbool("creative_mode") then
+
+-- Place node at player pos
+minetest.nodedef_default.on_secondary_use = function(itemstack, user, pointed)
+	local pos = user:getpos()
+	local s_name = itemstack:get_name()
+	minetest.set_node(pos, {name = s_name})
+end
+
 end


### PR DESCRIPTION
Requires Minetest pr #3382 to merge.

It is only used when pointing into the sky. I removed the place_at_location setting it becomes useless with this change.
